### PR TITLE
Agrego estado a los productos

### DIFF
--- a/backend/app/controllers/productos_controller.rb
+++ b/backend/app/controllers/productos_controller.rb
@@ -20,15 +20,15 @@ class ProductosController < ApplicationController
   end
 
   def show_figuras
-    render json: Producto.where(molde: "figura"), status: :ok
+    render json: Producto.where(molde: "figura", activo: true), status: :ok
   end
 
   def show_bombones
-    render json: Producto.where(molde: "bomboneria"), status: :ok
+    render json: Producto.where(molde: "bomboneria", activo: true), status: :ok
   end
 
   def show_huevos
-    render json: Producto.where(molde: "huevo"), status: :ok
+    render json: Producto.where(molde: "huevo", activo: true), status: :ok
   end
 
   def nombres
@@ -41,9 +41,10 @@ class ProductosController < ApplicationController
 
 
   def eliminar_producto
-    @producto = Producto.destroy(params[:id])
+    @producto = Producto.update(params[:id], :activo => false)
     render status: :ok, nothing: :true
   end
+
   def editar_producto
     @producto = Producto.update(params[:id], edicion_params )
     render json: @producto, status: :ok ,nothing: true

--- a/backend/db/migrate/20191109175012_agrego_estado_a_productos.rb
+++ b/backend/db/migrate/20191109175012_agrego_estado_a_productos.rb
@@ -1,0 +1,5 @@
+class AgregoEstadoAProductos < ActiveRecord::Migration
+  def change
+    add_column :productos, :activo, :boolean, :default => true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191019215253) do
+ActiveRecord::Schema.define(version: 20191109175012) do
 
   create_table "pedidos", force: :cascade do |t|
     t.datetime "created_at",                             null: false
@@ -28,8 +28,8 @@ ActiveRecord::Schema.define(version: 20191019215253) do
   end
 
   create_table "productos", force: :cascade do |t|
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.string   "nombre"
     t.integer  "precio"
     t.integer  "peso_en_gramos"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 20191019215253) do
     t.string   "picture"
     t.string   "molde"
     t.integer  "tamanio"
+    t.boolean  "activo",         default: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/backend/spec/controllers/productos_controller_spec.rb
+++ b/backend/spec/controllers/productos_controller_spec.rb
@@ -173,15 +173,15 @@ RSpec.describe ProductosController, type: :request do
 
   describe '#eliminar_producto' do
 
-=begin
-context 'cuando el producto no existe' do
-  let(:producto_id) {SecureRandom.uuid}
-  it 'retorna not found' do
-    delete "/productos/#{producto_id}"
-    expect(response).to have_http_status :not_found
-  end
-end
-=end
+
+    context 'cuando el producto no existe' do
+      let(:producto_id) {SecureRandom.uuid}
+      it 'retorna not found' do
+        delete "/productos/#{producto_id}"
+        expect(response).to have_http_status :not_found
+      end
+    end
+
     context 'cuando el producto existe' do
       let(:producto) do
         Producto.create!(nombre: 'Gallina', precio: 150.0, peso_en_gramos: 230, molde: 'figura', descripcion: 'paleta gallina')
@@ -189,7 +189,7 @@ end
 
       it 'se elimina el producto y retorna ok' do
         delete "/productos/#{producto.id}"
-        expect(Producto.exists?(producto.id)).to be_falsey
+        expect(Producto.find(producto.id).activo).to be_falsey
         expect(response).to have_http_status :ok
       end
     end

--- a/frontend-dolce-margarita/src/componentes/borradoDeProducto/ModalEliminarProducto.js
+++ b/frontend-dolce-margarita/src/componentes/borradoDeProducto/ModalEliminarProducto.js
@@ -1,0 +1,31 @@
+import React from "react";
+import './modalEliminarProducto.scss'
+import servicioEliminarProducto from "../../servicios/ServicioEliminarProducto";
+
+export default class ModalEliminarProducto extends React.Component {
+
+    render() {
+        return (
+            <div className="modal is-active">
+                <div className="modal-background"/>
+                <div className="modal-card">
+                    <header className="modal-card-head">
+                        <p className="modal-card-title title">Cuidado!</p>
+                        <button className="delete" aria-label="close" onClick={this.props.onClose}/>
+                    </header>
+
+                    <section className='modal-card-body'>
+                        <p>
+                            Estas a punto de borrar un producto. Esta operación no puede deshacerse. ¿Seguro que quieres continuar?
+                        </p>
+                    </section>
+                    <footer className="modal-card-foot">
+                        <button className="button boton-eliminar" onClick={this.props.onEliminar}>Eliminar</button>
+                        <button className="button is-danger" onClick={this.props.onClose}>Cancelar</button>
+                    </footer>
+                </div>
+            </div>
+
+        )
+    }
+}

--- a/frontend-dolce-margarita/src/componentes/borradoDeProducto/modalEliminarProducto.scss
+++ b/frontend-dolce-margarita/src/componentes/borradoDeProducto/modalEliminarProducto.scss
@@ -1,0 +1,40 @@
+$primary: #ffa5cd;
+
+@import "~bulma/bulma.sass";
+
+.modal {
+  width: 100%;
+  height: 100%;
+
+  .modal-card-head {
+    .modal-card-title{
+      margin: 0;
+      font-size: 35px;
+    }
+  }
+
+  .modal-card-body{
+    p {
+      margin: 0 0 5px 3px;
+    }
+
+    input, textarea {
+      margin: 0 0 10px 0;
+    }
+
+    .titulo-producto{
+      font-size: 28px;
+    }
+
+  }
+
+  .modal-card-foot {
+    justify-content: flex-end;
+
+    .boton-eliminar {
+      border-color: #e297a6;
+      background-color: #e297a6;
+      color: white;
+    }
+  }
+}

--- a/frontend-dolce-margarita/src/componentes/listadoDeProductos/ListadoDeProductos.js
+++ b/frontend-dolce-margarita/src/componentes/listadoDeProductos/ListadoDeProductos.js
@@ -6,6 +6,7 @@ import servicio from "../../servicios/servicio";
 import {withRouter} from "react-router-dom";
 import ModalEdicionProducto from "../edicionProducto/ModalEdicionProducto";
 import servicioEliminar from "../../servicios/ServicioEliminarProducto";
+import ModalEliminarProducto from "../borradoDeProducto/ModalEliminarProducto";
 
 class ListadoDeProductos extends React.Component {
     constructor(props) {
@@ -14,6 +15,7 @@ class ListadoDeProductos extends React.Component {
         this.state = {
             mostrarModalDeCompra: false,
             mostrarModalDeEdicion: false,
+            mostrarModalAdvertenciaBorrado: false,
             producto: null,
             productos: []
         }
@@ -49,6 +51,10 @@ class ListadoDeProductos extends React.Component {
         });
     };
 
+    mostrarModalAdvertencia = (producto) => {
+        this.setState({mostrarModalAdvertenciaBorrado: true, producto: producto})
+    }
+
     editarProducto = (producto) => {
         this.setState({
             producto,
@@ -56,8 +62,9 @@ class ListadoDeProductos extends React.Component {
         });
     }
 
-    eliminarProducto = (producto) => {
-        servicioEliminar.eliminarProducto(producto.id)
+    eliminarProducto = () => {
+        this.setState({mostrarModalAdvertenciaBorrado: false})
+        servicioEliminar.eliminarProducto(this.state.producto.id, this.actualizarProductosPostEdicion)
     }
 
     renderImage = (producto) => {
@@ -89,7 +96,7 @@ class ListadoDeProductos extends React.Component {
                     </a>}
 
                     {this.props.adminLogeado &&
-                         <a className="card-footer-item button is-danger" onClick={() => this.eliminarProducto(producto)}>
+                         <a className="card-footer-item button is-danger" onClick={() => this.mostrarModalAdvertencia(producto)}>
                         Eliminar
                      </a>}
 
@@ -125,6 +132,12 @@ class ListadoDeProductos extends React.Component {
             onClose={() => this.setState({mostrarModalDeEdicion: false})}
             esHuevo={this.props.moldeSeleccionado === 'huevos'}
             onEdit={this.actualizarProductosPostEdicion}
+        />}
+
+        {this.state.mostrarModalAdvertenciaBorrado &&
+        <ModalEliminarProducto
+            onClose={() => this.setState({mostrarModalAdvertenciaBorrado: false})}
+            onEliminar={() => this.eliminarProducto()}
         />}
         </div>
         )

--- a/frontend-dolce-margarita/src/componentes/listadoDeProductos/listadoDeProductos.scss
+++ b/frontend-dolce-margarita/src/componentes/listadoDeProductos/listadoDeProductos.scss
@@ -7,7 +7,8 @@ $button-color: #daddcb;
   display: flex;
   flex-direction: column;
   align-items: center;
-
+  position: fixed;
+  
   .cartas {
     display: grid;
     grid-template-columns: repeat(3, 1fr);

--- a/frontend-dolce-margarita/src/servicios/ServicioEliminarProducto.js
+++ b/frontend-dolce-margarita/src/servicios/ServicioEliminarProducto.js
@@ -3,9 +3,9 @@ const SERVICE_URL = 'http://localhost:3000/';
 
 export default class ServicioEliminarProducto {
 
-    static eliminarProducto(idProducto) {
+    static eliminarProducto(idProducto, postBorrado) {
         return axios.delete(`${SERVICE_URL}productos/` + idProducto)
-            .then(response => alert("Tu producto borro bien"))
+            .then(response => postBorrado())
             .catch(e => alert("la eliminacion fallo"))
     }
 }


### PR DESCRIPTION
Un producto se crea por default con su estado activo. Al borrar un producto ese estado pasa a ser falso. 
Al momento de obtener la lista de productos, el backend solo devuelve aquellos que estén activos. 
Se agregó un modal de confirmación previo al borrado de un producto.